### PR TITLE
feat: Add Concurrent Packet Handling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Changes
+
+- The `server` now concurrently process incoming packets from connections by calling handler functions in a goroutine.
+  This is done to avoid blocking the main packet processing loop when the handler for an incoming packet is slow.
+- The `UPDATE` Action has been completely removed from the `server` and the `client` - the context can no longer be
+  updated from a handler function.
+- The `SetConcurrency` function has been added to the `server` to set the concurrency of the packet processing
+  goroutines.
+
 ## [v0.5.4] - 2022-07-28 (Beta)
 
 ## Features

--- a/async_test.go
+++ b/async_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
-	"io/ioutil"
 	"net"
 	"runtime"
 	"sync"
@@ -38,7 +37,7 @@ func TestNewAsync(t *testing.T) {
 
 	const packetSize = 512
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -95,7 +94,7 @@ func TestAsyncLargeWrite(t *testing.T) {
 	const testSize = 100000
 	const packetSize = 512
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -142,7 +141,7 @@ func TestAsyncRawConn(t *testing.T) {
 	const testSize = 100000
 	const packetSize = 32
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	require.NoError(t, err)
@@ -204,7 +203,7 @@ func TestAsyncReadClose(t *testing.T) {
 
 	reader, writer := net.Pipe()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	readerConn := NewAsync(reader, &emptyLogger)
 	writerConn := NewAsync(writer, &emptyLogger)
@@ -252,7 +251,7 @@ func TestAsyncReadAvailableClose(t *testing.T) {
 
 	reader, writer := net.Pipe()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	readerConn := NewAsync(reader, &emptyLogger)
 	writerConn := NewAsync(writer, &emptyLogger)
@@ -302,7 +301,7 @@ func TestAsyncWriteClose(t *testing.T) {
 
 	reader, writer := net.Pipe()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	readerConn := NewAsync(reader, &emptyLogger)
 	writerConn := NewAsync(writer, &emptyLogger)
@@ -352,7 +351,7 @@ func TestAsyncWriteClose(t *testing.T) {
 func TestAsyncTimeout(t *testing.T) {
 	t.Parallel()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	require.NoError(t, err)
@@ -431,7 +430,7 @@ func TestAsyncTimeout(t *testing.T) {
 func BenchmarkAsyncThroughputPipe(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -451,7 +450,7 @@ func BenchmarkAsyncThroughputPipe(b *testing.B) {
 func BenchmarkAsyncThroughputNetwork(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	if err != nil {
@@ -530,7 +529,7 @@ func BenchmarkAsyncThroughputNetworkMultiple(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < numClients; i++ {
 				go func() {
-					emptyLogger := zerolog.New(ioutil.Discard)
+					emptyLogger := zerolog.New(io.Discard)
 
 					reader, writer, err := pair.New()
 					if err != nil {

--- a/async_test.go
+++ b/async_test.go
@@ -380,7 +380,7 @@ func TestAsyncTimeout(t *testing.T) {
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)
 	assert.Equal(t, 0, len(*p.Content))
 
-	time.Sleep(DefaultDeadline * 5)
+	time.Sleep(DefaultDeadline * 2)
 
 	err = writerConn.Error()
 	require.NoError(t, err)
@@ -400,7 +400,7 @@ func TestAsyncTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	runtime.Gosched()
-	time.Sleep(DefaultDeadline * 5)
+	time.Sleep(DefaultDeadline * 2)
 	runtime.Gosched()
 
 	p, err = readerConn.ReadPacket()
@@ -417,7 +417,7 @@ func TestAsyncTimeout(t *testing.T) {
 	err = readerConn.Error()
 	if err == nil {
 		runtime.Gosched()
-		time.Sleep(DefaultDeadline * 10)
+		time.Sleep(DefaultDeadline * 3)
 		runtime.Gosched()
 	}
 	require.Error(t, readerConn.Error())

--- a/client.go
+++ b/client.go
@@ -215,10 +215,6 @@ LOOP:
 		}
 		switch action {
 		case NONE:
-		case UPDATE:
-			if c.UpdateContext != nil {
-				c.ctx = c.UpdateContext(c.ctx, c.conn)
-			}
 		case CLOSE:
 			c.Logger().Debug().Msgf("Closing connection %s because of CLOSE action", c.conn.RemoteAddr())
 			c.wg.Done()

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 )
@@ -63,7 +63,7 @@ func TestClientRaw(t *testing.T) {
 		return
 	}
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
 
@@ -156,7 +156,7 @@ func TestClientStaleClose(t *testing.T) {
 		return
 	}
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func BenchmarkThroughputClient(b *testing.B) {
 		return
 	}
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	if err != nil {
 		b.Fatal(err)
@@ -297,7 +297,7 @@ func BenchmarkThroughputResponseClient(b *testing.B) {
 		return
 	}
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	if err != nil {
 		b.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -67,6 +67,8 @@ func TestClientRaw(t *testing.T) {
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
 
+	s.SetConcurrency(1)
+
 	s.ConnContext = func(ctx context.Context, c *Async) context.Context {
 		return context.WithValue(ctx, clientConnContextKey, c)
 	}
@@ -160,6 +162,8 @@ func TestClientStaleClose(t *testing.T) {
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
 
+	s.SetConcurrency(1)
+
 	serverConn, clientConn, err := pair.New()
 	require.NoError(t, err)
 
@@ -219,6 +223,8 @@ func BenchmarkThroughputClient(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	s.SetConcurrency(1)
 
 	serverConn, clientConn, err := pair.New()
 	if err != nil {
@@ -302,6 +308,8 @@ func BenchmarkThroughputResponseClient(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	s.SetConcurrency(1)
 
 	serverConn, clientConn, err := pair.New()
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -22,7 +22,7 @@ import (
 	"github.com/loopholelabs/frisbee-go/pkg/packet"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"io/ioutil"
+	"io"
 	"net"
 	"time"
 )
@@ -31,7 +31,7 @@ import (
 const DefaultBufferSize = 1 << 16
 
 var (
-	defaultLogger = zerolog.New(ioutil.Discard)
+	defaultLogger = zerolog.New(io.Discard)
 
 	DefaultDeadline = time.Second * 5
 

--- a/doc.go
+++ b/doc.go
@@ -32,8 +32,8 @@
 //	package main
 //
 //	import (
-//		"github.com/loopholelabs/frisbee"
-//      "github.com/loopholelabs/frisbee/pkg/packet"
+//		"github.com/loopholelabs/frisbee-go"
+//      "github.com/loopholelabs/frisbee-go/pkg/packet"
 //		"github.com/rs/zerolog/log"
 //		"os"
 //		"os/signal"
@@ -76,8 +76,8 @@
 //
 //	import (
 //		"fmt"
-//		"github.com/loopholelabs/frisbee"
-//		"github.com/loopholelabs/frisbee/pkg/packet"
+//		"github.com/loopholelabs/frisbee-go"
+//		"github.com/loopholelabs/frisbee-go/pkg/packet"
 //		"github.com/rs/zerolog/log"
 //		"os"
 //		"os/signal"

--- a/doc.go
+++ b/doc.go
@@ -24,54 +24,54 @@
 //
 // In depth documentation and examples can be found at https://loopholelabs.io/docs/frisbee
 //
-//
-// An Echo Example
+// # An Echo Example
 //
 // As a starting point, a very basic echo server:
 //
-//	package main
+//		package main
 //
-//	import (
-//		"github.com/loopholelabs/frisbee-go"
-//      "github.com/loopholelabs/frisbee-go/pkg/packet"
-//		"github.com/rs/zerolog/log"
-//		"os"
-//		"os/signal"
-//	)
+//		import (
+//			"github.com/loopholelabs/frisbee-go"
+//	     "github.com/loopholelabs/frisbee-go/pkg/packet"
+//			"github.com/rs/zerolog/log"
+//			"os"
+//			"os/signal"
+//		)
 //
-//	const PING = uint16(10)
-//	const PONG = uint16(11)
+//		const PING = uint16(10)
+//		const PONG = uint16(11)
 //
-//	func handlePing(_ *frisbee.Async, incoming *packet.Packet) (outgoing *packet.Packet, action frisbee.Action) {
-//		if incoming.Metadata.ContentLength > 0 {
-//			log.Printf("Server Received Metadata: %s\n", incoming.Content)
-//          incoming.Metadata.Operation = PONG
-//			outgoing = incoming
+//		func handlePing(_ *frisbee.Async, incoming *packet.Packet) (outgoing *packet.Packet, action frisbee.Action) {
+//			if incoming.Metadata.ContentLength > 0 {
+//				log.Printf("Server Received Metadata: %s\n", incoming.Content)
+//	         incoming.Metadata.Operation = PONG
+//				outgoing = incoming
+//			}
+//
+//			return
 //		}
 //
-//		return
-//	}
+//		func main() {
+//			handlerTable := make(frisbee.ServerRouter)
+//			handlerTable[PING] = handlePing
+//			exit := make(chan os.Signal)
+//			signal.Notify(exit, os.Interrupt)
 //
-//	func main() {
-//		handlerTable := make(frisbee.ServerRouter)
-//		handlerTable[PING] = handlePing
-//		exit := make(chan os.Signal)
-//		signal.Notify(exit, os.Interrupt)
+//			s := frisbee.NewServer(":8192", handlerTable, 0)
+//			err := s.Start()
+//			if err != nil {
+//				panic(err)
+//			}
 //
-//		s := frisbee.NewServer(":8192", handlerTable, 0)
-//		err := s.Start()
-//		if err != nil {
-//			panic(err)
+//			<-exit
+//			err = s.Shutdown()
+//			if err != nil {
+//				panic(err)
+//			}
 //		}
-//
-//		<-exit
-//		err = s.Shutdown()
-//		if err != nil {
-//			panic(err)
-//		}
-//	}
 //
 // And an accompanying echo client:
+//
 //	package main
 //
 //	import (

--- a/frisbee.go
+++ b/frisbee.go
@@ -31,7 +31,7 @@ var (
 	ConnectionClosed         = errors.New("connection closed")
 	ConnectionNotInitialized = errors.New("connection not initialized")
 	InvalidBufferLength      = errors.New("invalid buffer length")
-	InvalidHandlerTable      = errors.New("invalid handlePacket table configuration, a reserved value may have been used")
+	InvalidHandlerTable      = errors.New("invalid handler table configuration, a reserved value may have been used")
 )
 
 // Action is an ENUM used to modify the state of the client or server from a Handler function
@@ -45,9 +45,6 @@ type Action int
 const (
 	// NONE is used to do nothing (default)
 	NONE = Action(iota)
-
-	// UPDATE is used to trigger an UpdateContext call on the Server or Client
-	UPDATE
 
 	// CLOSE is used to close the frisbee connection
 	CLOSE

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/loopholelabs/frisbee-go
 go 1.18
 
 require (
-	github.com/loopholelabs/common v0.2.0
+	github.com/loopholelabs/common v0.4.2
 	github.com/loopholelabs/polyglot-go v0.3.0
 	github.com/loopholelabs/testing v0.2.3
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/loopholelabs/frisbee-go
 go 1.18
 
 require (
-	github.com/loopholelabs/common v0.4.2
+	github.com/loopholelabs/common v0.4.4
 	github.com/loopholelabs/polyglot-go v0.3.0
 	github.com/loopholelabs/testing v0.2.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/loopholelabs/common v0.4.2 h1:agyKRjPU9dwxgVgEh2ME+GlTw2ktlb/uqmxw4SEovbI=
-github.com/loopholelabs/common v0.4.2/go.mod h1:OoB+RYcKNb3/TkwK5K29LVaJMBT606aBs+FUv8piW2g=
+github.com/loopholelabs/common v0.4.4 h1:Ge+1v1WiLYgR/4pziOQoJAwUqUm1c9j6nQvnkiFFBsk=
+github.com/loopholelabs/common v0.4.4/go.mod h1:YKnljczr4jgxkHhhAwIHh3CJXaff89YBd8Vp3pwpG3k=
 github.com/loopholelabs/polyglot-go v0.3.0 h1:iOqPw5B3krCMYfgDaPgPoh1A87ACE8lKdbpbERM58pY=
 github.com/loopholelabs/polyglot-go v0.3.0/go.mod h1:9/Hr1nFO9Al46806vMP3DB2k8blQ3gazBPaoOsdgo34=
 github.com/loopholelabs/testing v0.2.3 h1:4nVuK5ctaE6ua5Z0dYk2l7xTFmcpCYLUeGjRBp8keOA=

--- a/go.sum
+++ b/go.sum
@@ -8,9 +8,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/loopholelabs/common v0.2.0 h1:irIV5qsMK2ghO7Bu1XSXnN/6rtP5mazSE1WSBDhi/eg=
-github.com/loopholelabs/common v0.2.0/go.mod h1:hB8T0eBGDcZ4cvBfDoD3yUs6bUzeZed9VqhzN4lI7nU=
-github.com/loopholelabs/frisbee v0.5.0 h1:wB/PggORrg3IxqppNsSSvRdKG5w3F1A8tRxQhPVvmCI=
+github.com/loopholelabs/common v0.4.2 h1:agyKRjPU9dwxgVgEh2ME+GlTw2ktlb/uqmxw4SEovbI=
+github.com/loopholelabs/common v0.4.2/go.mod h1:OoB+RYcKNb3/TkwK5K29LVaJMBT606aBs+FUv8piW2g=
 github.com/loopholelabs/polyglot-go v0.3.0 h1:iOqPw5B3krCMYfgDaPgPoh1A87ACE8lKdbpbERM58pY=
 github.com/loopholelabs/polyglot-go v0.3.0/go.mod h1:9/Hr1nFO9Al46806vMP3DB2k8blQ3gazBPaoOsdgo34=
 github.com/loopholelabs/testing v0.2.3 h1:4nVuK5ctaE6ua5Z0dYk2l7xTFmcpCYLUeGjRBp8keOA=

--- a/options.go
+++ b/options.go
@@ -19,7 +19,7 @@ package frisbee
 import (
 	"crypto/tls"
 	"github.com/rs/zerolog"
-	"io/ioutil"
+	"io"
 	"time"
 )
 
@@ -27,11 +27,12 @@ import (
 type Option func(opts *Options)
 
 // DefaultLogger is the default logger used within frisbee
-var DefaultLogger = zerolog.New(ioutil.Discard)
+var DefaultLogger = zerolog.New(io.Discard)
 
 // Options is used to provide the frisbee client and server with configuration options.
 //
 // Default Values:
+//
 //	options := Options {
 //		KeepAlive: time.Minute * 3,
 //		Logger: &DefaultLogger,

--- a/options_test.go
+++ b/options_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 )
@@ -73,7 +73,7 @@ func TestDisableOptions(t *testing.T) {
 func TestIndividualOptions(t *testing.T) {
 	t.Parallel()
 
-	logger := zerolog.New(ioutil.Discard)
+	logger := zerolog.New(io.Discard)
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}

--- a/server.go
+++ b/server.go
@@ -19,7 +19,6 @@ package frisbee
 import (
 	"context"
 	"crypto/tls"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -181,7 +180,6 @@ func (s *Server) Start(addr string) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("adding 1 to wg\n")
 	s.wg.Add(1)
 	close(s.startedCh)
 	return s.handleListener()
@@ -332,7 +330,6 @@ func (s *Server) handleUnlimitedPacket(frisbeeConn *Async, connCtx context.Conte
 			packet.Put(p)
 		}
 		wg.Done()
-		return
 	}
 HANDLE:
 	wg.Add(1)
@@ -404,7 +401,6 @@ func (s *Server) handleLimitedPacket(frisbeeConn *Async, connCtx context.Context
 		}
 		<-s.limiter
 		wg.Done()
-		return
 	}
 HANDLE:
 	select {

--- a/server.go
+++ b/server.go
@@ -153,7 +153,11 @@ func (s *Server) GetHandlerTable() HandlerTable {
 }
 
 // SetConcurrency sets the maximum number of concurrent goroutines that will be created
-// to handle incoming packets from connections on a per-connection basis.
+// by the server to handle incoming packets.
+//
+// An important caveat of this is that handlers must always thread-safe if they share resources
+// between connections. If the concurrency is set to a value != 1, then the handlers
+// must also be thread-safe if they share resources per connection.
 //
 // This function should not be called once the server has started.
 func (s *Server) SetConcurrency(concurrency uint64) {

--- a/server_test.go
+++ b/server_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"io/ioutil"
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 // trunk-ignore-all(golangci-lint/staticcheck)
@@ -302,6 +304,282 @@ func TestServerMultipleConnections(t *testing.T) {
 	t.Run("100", func(t *testing.T) { runner(t, 100) })
 }
 
+func TestServerRawUnlimited(t *testing.T) {
+	t.Parallel()
+
+	const testSize = 100
+	const packetSize = 512
+	clientHandlerTable := make(HandlerTable)
+	serverHandlerTable := make(HandlerTable)
+
+	serverIsRaw := make(chan struct{}, 1)
+
+	serverHandlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		return
+	}
+
+	var rawServerConn, rawClientConn net.Conn
+	serverHandlerTable[metadata.PacketProbe] = func(ctx context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		c := ctx.Value(serverConnContextKey).(*Async)
+		rawServerConn = c.Raw()
+		serverIsRaw <- struct{}{}
+		return
+	}
+
+	clientHandlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
+	require.NoError(t, err)
+
+	s.SetConcurrency(0)
+
+	s.ConnContext = func(ctx context.Context, c *Async) context.Context {
+		return context.WithValue(ctx, serverConnContextKey, c)
+	}
+
+	serverConn, clientConn, err := pair.New()
+	require.NoError(t, err)
+
+	go s.ServeConn(serverConn)
+
+	c, err := NewClient(clientHandlerTable, context.Background(), WithLogger(&emptyLogger))
+	assert.NoError(t, err)
+
+	_, err = c.Raw()
+	assert.ErrorIs(t, ConnectionNotInitialized, err)
+
+	err = c.FromConn(clientConn)
+	assert.NoError(t, err)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+	p := packet.Get()
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+	p.Metadata.Operation = metadata.PacketPing
+	assert.Equal(t, polyglot.Buffer(data), *p.Content)
+
+	for q := 0; q < testSize; q++ {
+		p.Metadata.Id = uint16(q)
+		err = c.WritePacket(p)
+		assert.NoError(t, err)
+	}
+
+	p.Reset()
+	assert.Equal(t, 0, len(*p.Content))
+	p.Metadata.Operation = metadata.PacketProbe
+
+	err = c.WritePacket(p)
+	require.NoError(t, err)
+
+	packet.Put(p)
+
+	rawClientConn, err = c.Raw()
+	require.NoError(t, err)
+
+	<-serverIsRaw
+
+	serverBytes := []byte("SERVER WRITE")
+
+	write, err := rawServerConn.Write(serverBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, len(serverBytes), write)
+
+	clientBuffer := make([]byte, len(serverBytes))
+	read, err := rawClientConn.Read(clientBuffer)
+	assert.NoError(t, err)
+	assert.Equal(t, len(serverBytes), read)
+
+	assert.Equal(t, serverBytes, clientBuffer)
+
+	err = c.Close()
+	assert.NoError(t, err)
+	err = rawClientConn.Close()
+	assert.NoError(t, err)
+
+	err = s.Shutdown()
+	assert.NoError(t, err)
+	err = rawServerConn.Close()
+	assert.NoError(t, err)
+}
+
+func TestServerStaleCloseUnlimited(t *testing.T) {
+	t.Parallel()
+
+	const testSize = 100
+	const packetSize = 512
+	clientHandlerTable := make(HandlerTable)
+	serverHandlerTable := make(HandlerTable)
+
+	finished := make(chan struct{}, 1)
+
+	count := atomic.NewUint32(0)
+	serverHandlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+		if count.Load() == testSize-1 {
+			outgoing = incoming
+			action = CLOSE
+		} else {
+			count.Inc()
+		}
+		return
+	}
+
+	clientHandlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		finished <- struct{}{}
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
+	require.NoError(t, err)
+
+	s.SetConcurrency(0)
+
+	serverConn, clientConn, err := pair.New()
+	require.NoError(t, err)
+
+	go s.ServeConn(serverConn)
+
+	c, err := NewClient(clientHandlerTable, context.Background(), WithLogger(&emptyLogger))
+	assert.NoError(t, err)
+	_, err = c.Raw()
+	assert.ErrorIs(t, ConnectionNotInitialized, err)
+
+	err = c.FromConn(clientConn)
+	require.NoError(t, err)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+	p := packet.Get()
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+	p.Metadata.Operation = metadata.PacketPing
+	assert.Equal(t, polyglot.Buffer(data), *p.Content)
+
+	for q := 0; q < testSize; q++ {
+		p.Metadata.Id = uint16(q)
+		err = c.WritePacket(p)
+		assert.NoError(t, err)
+	}
+	packet.Put(p)
+	<-finished
+
+	_, err = c.conn.ReadPacket()
+	assert.ErrorIs(t, err, ConnectionClosed)
+
+	err = c.Close()
+	assert.NoError(t, err)
+
+	err = s.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServerMultipleConnectionsUnlimited(t *testing.T) {
+	t.Parallel()
+
+	const testSize = 100
+	const packetSize = 512
+
+	runner := func(t *testing.T, num int) {
+		finished := make([]chan struct{}, num)
+		clientTables := make([]HandlerTable, num)
+		for i := 0; i < num; i++ {
+			idx := i
+			finished[idx] = make(chan struct{}, 1)
+			clientTables[i] = make(HandlerTable)
+			clientTables[i][metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+				finished[idx] <- struct{}{}
+				return
+			}
+		}
+		count := atomic.NewUint32(0)
+
+		serverHandlerTable := make(HandlerTable)
+		serverHandlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+			if count.Load() == testSize-1 {
+				outgoing = incoming
+				action = CLOSE
+			} else {
+				count.Inc()
+			}
+			return
+		}
+
+		emptyLogger := zerolog.New(ioutil.Discard)
+		s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
+		require.NoError(t, err)
+
+		s.SetConcurrency(0)
+
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			err := s.Start(conn.Listen)
+			require.NoError(t, err)
+			wg.Done()
+		}()
+
+		<-s.started()
+		listenAddr := s.listener.Addr().String()
+
+		clients := make([]*Client, num)
+		for i := 0; i < num; i++ {
+			clients[i], err = NewClient(clientTables[i], context.Background(), WithLogger(&emptyLogger))
+			assert.NoError(t, err)
+			_, err = clients[i].Raw()
+			assert.ErrorIs(t, ConnectionNotInitialized, err)
+
+			err = clients[i].Connect(listenAddr)
+			require.NoError(t, err)
+		}
+
+		data := make([]byte, packetSize)
+		_, err = rand.Read(data)
+		assert.NoError(t, err)
+
+		var clientWg sync.WaitGroup
+		for i := 0; i < num; i++ {
+			idx := i
+			clientWg.Add(1)
+			go func() {
+				p := packet.Get()
+				p.Content.Write(data)
+				p.Metadata.ContentLength = packetSize
+				p.Metadata.Operation = metadata.PacketPing
+				assert.Equal(t, polyglot.Buffer(data), *p.Content)
+				for q := 0; q < testSize; q++ {
+					p.Metadata.Id = uint16(q)
+					err := clients[idx].WritePacket(p)
+					assert.NoError(t, err)
+				}
+				<-finished[idx]
+				err := clients[idx].Close()
+				assert.NoError(t, err)
+				clientWg.Done()
+				packet.Put(p)
+			}()
+		}
+
+		clientWg.Wait()
+
+		err = s.Shutdown()
+		assert.NoError(t, err)
+		wg.Wait()
+
+	}
+
+	t.Run("1", func(t *testing.T) { runner(t, 1) })
+	t.Run("2", func(t *testing.T) { runner(t, 2) })
+	t.Run("3", func(t *testing.T) { runner(t, 3) })
+	t.Run("5", func(t *testing.T) { runner(t, 5) })
+	t.Run("10", func(t *testing.T) { runner(t, 10) })
+	t.Run("100", func(t *testing.T) { runner(t, 100) })
+}
+
 func BenchmarkThroughputServer(b *testing.B) {
 	const testSize = 1<<16 - 1
 	const packetSize = 512
@@ -317,6 +595,134 @@ func BenchmarkThroughputServer(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	serverConn, clientConn, err := pair.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	go server.ServeConn(serverConn)
+
+	frisbeeConn := NewAsync(clientConn, &emptyLogger)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+	p := packet.Get()
+	p.Metadata.Operation = metadata.PacketPing
+
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+
+	b.Run("test", func(b *testing.B) {
+		b.SetBytes(testSize * packetSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for q := 0; q < testSize; q++ {
+				p.Metadata.Id = uint16(q)
+				err = frisbeeConn.WritePacket(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+	b.StopTimer()
+
+	packet.Put(p)
+
+	err = frisbeeConn.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = server.Shutdown()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkThroughputServerUnlimited(b *testing.B) {
+	const testSize = 1<<16 - 1
+	const packetSize = 512
+
+	handlerTable := make(HandlerTable)
+
+	handlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		time.Sleep(time.Millisecond * 50)
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	server, err := NewServer(handlerTable, WithLogger(&emptyLogger))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	server.SetConcurrency(0)
+
+	serverConn, clientConn, err := pair.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	go server.ServeConn(serverConn)
+
+	frisbeeConn := NewAsync(clientConn, &emptyLogger)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+	p := packet.Get()
+	p.Metadata.Operation = metadata.PacketPing
+
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+
+	b.Run("test", func(b *testing.B) {
+		b.SetBytes(testSize * packetSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for q := 0; q < testSize; q++ {
+				p.Metadata.Id = uint16(q)
+				err = frisbeeConn.WritePacket(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+	b.StopTimer()
+
+	packet.Put(p)
+
+	err = frisbeeConn.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = server.Shutdown()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkThroughputServerLimited(b *testing.B) {
+	const testSize = 1<<16 - 1
+	const packetSize = 512
+
+	handlerTable := make(HandlerTable)
+
+	handlerTable[metadata.PacketPing] = func(_ context.Context, _ *packet.Packet) (outgoing *packet.Packet, action Action) {
+		time.Sleep(time.Millisecond * 50)
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	server, err := NewServer(handlerTable, WithLogger(&emptyLogger))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	server.SetConcurrency(1 << 14)
 
 	serverConn, clientConn, err := pair.New()
 	if err != nil {
@@ -389,6 +795,177 @@ func BenchmarkThroughputResponseServer(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	go server.ServeConn(serverConn)
+
+	frisbeeConn := NewAsync(clientConn, &emptyLogger)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+
+	p := packet.Get()
+	p.Metadata.Operation = metadata.PacketPing
+
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+
+	b.Run("test", func(b *testing.B) {
+		b.SetBytes(testSize * packetSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for q := 0; q < testSize; q++ {
+				p.Metadata.Id = uint16(q)
+				err = frisbeeConn.WritePacket(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			readPacket, err := frisbeeConn.ReadPacket()
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if readPacket.Metadata.Id != testSize {
+				b.Fatal("invalid decoded metadata id", readPacket.Metadata.Id)
+			}
+
+			if readPacket.Metadata.Operation != metadata.PacketPong {
+				b.Fatal("invalid decoded operation", readPacket.Metadata.Operation)
+			}
+			packet.Put(readPacket)
+		}
+
+	})
+	b.StopTimer()
+
+	packet.Put(p)
+
+	err = frisbeeConn.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = server.Shutdown()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkThroughputResponseServerSlow(b *testing.B) {
+	const testSize = 1<<16 - 1
+	const packetSize = 512
+
+	serverConn, clientConn, err := pair.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	handlerTable := make(HandlerTable)
+
+	handlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+		time.Sleep(time.Microsecond * 50)
+		if incoming.Metadata.Id == testSize-1 {
+			incoming.Reset()
+			incoming.Metadata.Id = testSize
+			incoming.Metadata.Operation = metadata.PacketPong
+			outgoing = incoming
+		}
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	server, err := NewServer(handlerTable, WithLogger(&emptyLogger))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	go server.ServeConn(serverConn)
+
+	frisbeeConn := NewAsync(clientConn, &emptyLogger)
+
+	data := make([]byte, packetSize)
+	_, _ = rand.Read(data)
+
+	p := packet.Get()
+	p.Metadata.Operation = metadata.PacketPing
+
+	p.Content.Write(data)
+	p.Metadata.ContentLength = packetSize
+
+	b.Run("test", func(b *testing.B) {
+		b.SetBytes(testSize * packetSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for q := 0; q < testSize; q++ {
+				p.Metadata.Id = uint16(q)
+				err = frisbeeConn.WritePacket(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			readPacket, err := frisbeeConn.ReadPacket()
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if readPacket.Metadata.Id != testSize {
+				b.Fatal("invalid decoded metadata id", readPacket.Metadata.Id)
+			}
+
+			if readPacket.Metadata.Operation != metadata.PacketPong {
+				b.Fatal("invalid decoded operation", readPacket.Metadata.Operation)
+			}
+			packet.Put(readPacket)
+		}
+
+	})
+	b.StopTimer()
+
+	packet.Put(p)
+
+	err = frisbeeConn.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = server.Shutdown()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkThroughputResponseServerSlowUnlimited(b *testing.B) {
+	const testSize = 1<<16 - 1
+	const packetSize = 512
+
+	serverConn, clientConn, err := pair.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	handlerTable := make(HandlerTable)
+
+	count := atomic.NewUint32(0)
+	handlerTable[metadata.PacketPing] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
+		time.Sleep(time.Microsecond * 50)
+		if count.Load() == testSize-1 {
+			incoming.Reset()
+			incoming.Metadata.Id = testSize
+			incoming.Metadata.Operation = metadata.PacketPong
+			outgoing = incoming
+		} else {
+			count.Inc()
+		}
+		return
+	}
+
+	emptyLogger := zerolog.New(ioutil.Discard)
+	server, err := NewServer(handlerTable, WithLogger(&emptyLogger))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	server.SetConcurrency(0)
 
 	go server.ServeConn(serverConn)
 

--- a/server_test.go
+++ b/server_test.go
@@ -41,7 +41,7 @@ const (
 	serverConnContextKey = "conn"
 )
 
-func TestServerRaw(t *testing.T) {
+func TestServerRawSingle(t *testing.T) {
 	t.Parallel()
 
 	const testSize = 100
@@ -70,6 +70,8 @@ func TestServerRaw(t *testing.T) {
 	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
+
+	s.SetConcurrency(1)
 
 	s.ConnContext = func(ctx context.Context, c *Async) context.Context {
 		return context.WithValue(ctx, serverConnContextKey, c)
@@ -141,7 +143,7 @@ func TestServerRaw(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestServerStaleClose(t *testing.T) {
+func TestServerStaleCloseSingle(t *testing.T) {
 	t.Parallel()
 
 	const testSize = 100
@@ -167,6 +169,8 @@ func TestServerStaleClose(t *testing.T) {
 	emptyLogger := zerolog.New(io.Discard)
 	s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 	require.NoError(t, err)
+
+	s.SetConcurrency(1)
 
 	serverConn, clientConn, err := pair.New()
 	require.NoError(t, err)
@@ -207,7 +211,7 @@ func TestServerStaleClose(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestServerMultipleConnections(t *testing.T) {
+func TestServerMultipleConnectionsSingle(t *testing.T) {
 	t.Parallel()
 
 	const testSize = 100
@@ -237,6 +241,8 @@ func TestServerMultipleConnections(t *testing.T) {
 		emptyLogger := zerolog.New(io.Discard)
 		s, err := NewServer(serverHandlerTable, WithLogger(&emptyLogger))
 		require.NoError(t, err)
+
+		s.SetConcurrency(1)
 
 		var wg sync.WaitGroup
 
@@ -683,7 +689,7 @@ func TestServerMultipleConnectionsLimited(t *testing.T) {
 	t.Run("100", func(t *testing.T) { runner(t, 100) })
 }
 
-func BenchmarkThroughputServer(b *testing.B) {
+func BenchmarkThroughputServerSingle(b *testing.B) {
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -698,6 +704,8 @@ func BenchmarkThroughputServer(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	server.SetConcurrency(1)
 
 	serverConn, clientConn, err := pair.New()
 	if err != nil {
@@ -872,7 +880,7 @@ func BenchmarkThroughputServerLimited(b *testing.B) {
 	}
 }
 
-func BenchmarkThroughputResponseServer(b *testing.B) {
+func BenchmarkThroughputResponseServerSingle(b *testing.B) {
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -898,6 +906,8 @@ func BenchmarkThroughputResponseServer(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	server.SetConcurrency(1)
 
 	go server.ServeConn(serverConn)
 
@@ -954,7 +964,7 @@ func BenchmarkThroughputResponseServer(b *testing.B) {
 	}
 }
 
-func BenchmarkThroughputResponseServerSlow(b *testing.B) {
+func BenchmarkThroughputResponseServerSlowSingle(b *testing.B) {
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -981,6 +991,8 @@ func BenchmarkThroughputResponseServerSlow(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
+	server.SetConcurrency(1)
 
 	go server.ServeConn(serverConn)
 

--- a/sync_test.go
+++ b/sync_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 )
@@ -34,7 +33,7 @@ func TestNewSync(t *testing.T) {
 	t.Parallel()
 	const packetSize = 512
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -105,7 +104,7 @@ func TestSyncLargeWrite(t *testing.T) {
 	const testSize = 100000
 	const packetSize = 512
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -163,7 +162,7 @@ func TestSyncRawConn(t *testing.T) {
 	const testSize = 100000
 	const packetSize = 32
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	require.NoError(t, err)
@@ -236,7 +235,7 @@ func TestSyncReadClose(t *testing.T) {
 
 	reader, writer := net.Pipe()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	readerConn := NewSync(reader, &emptyLogger)
 	writerConn := NewSync(writer, &emptyLogger)
@@ -286,7 +285,7 @@ func TestSyncWriteClose(t *testing.T) {
 
 	reader, writer := net.Pipe()
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	readerConn := NewSync(reader, &emptyLogger)
 	writerConn := NewSync(writer, &emptyLogger)
@@ -334,7 +333,7 @@ func TestSyncWriteClose(t *testing.T) {
 func BenchmarkSyncThroughputPipe(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer := net.Pipe()
 
@@ -354,7 +353,7 @@ func BenchmarkSyncThroughputPipe(b *testing.B) {
 func BenchmarkSyncThroughputNetwork(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	if err != nil {

--- a/throughput_test.go
+++ b/throughput_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/loopholelabs/testing/conn/pair"
 	"github.com/rs/zerolog"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ import (
 func BenchmarkAsyncThroughputLarge(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	if err != nil {
@@ -56,7 +55,7 @@ func BenchmarkAsyncThroughputLarge(b *testing.B) {
 func BenchmarkSyncThroughputLarge(b *testing.B) {
 	const testSize = 100
 
-	emptyLogger := zerolog.New(ioutil.Discard)
+	emptyLogger := zerolog.New(io.Discard)
 
 	reader, writer, err := pair.New()
 	if err != nil {


### PR DESCRIPTION
## Description

This PR allows the server to be configured to provide concurrent packet processing on a per-connection basis. 

The concurrency value of `1` specifies that a single goroutine should handle all incoming packets for a connection and process them synchronously. When the concurrency is set to `0` (the default), we're specifying that an unlimited number of goroutines can be spawned to handle incoming packets from connections, and a concurrency value of > 1 sets a limit to the number of goroutines that can be created to concurrently handle packets.

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`),
and if required please add new test cases and list them below:

- [x] TestServerRawUnlimited
- [x] TestServerStaleCloseUnlimited
- [x] TestServerMultipleConnectionsUnlimited
- [x] TestServerMultipleConnectionsLimited
- [x] BenchmarkThroughputServerUnlimited
- [x] BenchmarkThroughputServerLimited
- [x] BenchmarkThroughputResponseServerSlow
- [x] BenchmarkThroughputResponseServerSlowUnlimited
- [x] BenchmarkThroughputResponseServerSlowLimited

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee-go
BenchmarkAsyncThroughputPipe/32_Bytes-10                  106316             10524 ns/op         304.07 MB/s         458 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/512_Bytes-10                  91135             13046 ns/op        3924.68 MB/s         453 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/1024_Bytes-10                 59348             19887 ns/op        5149.12 MB/s         467 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/2048_Bytes-10                 43896             27053 ns/op        7570.45 MB/s         474 B/op          8 allocs/op
BenchmarkAsyncThroughputPipe/4096_Bytes-10                 26628             44845 ns/op        9133.59 MB/s         520 B/op          9 allocs/op
BenchmarkAsyncThroughputNetwork/32_Bytes-10                53089             21379 ns/op         149.68 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/512_Bytes-10               44110             27125 ns/op        1887.53 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/1024_Bytes-10              34908             34166 ns/op        2997.10 MB/s         259 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/2048_Bytes-10              26740             44678 ns/op        4583.91 MB/s         260 B/op          4 allocs/op
BenchmarkAsyncThroughputNetwork/4096_Bytes-10              18402             65297 ns/op        6272.91 MB/s         263 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_32_Bytes-10                56328             21437 ns/op         149.28 MB/s         300 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_32_Bytes-10                46509             25521 ns/op         125.39 MB/s         626 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_32_Bytes-10                35210             31534 ns/op         101.48 MB/s        1647 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_32_Bytes-10               16687             63140 ns/op          50.68 MB/s        4065 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_32_Bytes-10         37801             31477 ns/op         101.66 MB/s        1623 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_32_Bytes-10              18969             61965 ns/op          51.64 MB/s        3887 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_32_Bytes-10                7096            155702 ns/op          20.55 MB/s       12007 B/op         81 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_512_Bytes-10                       43513             27359 ns/op        1871.38 MB/s         314 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_512_Bytes-10                       38317             30913 ns/op        1656.25 MB/s         648 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_512_Bytes-10                       29989             38941 ns/op        1314.80 MB/s        1712 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_512_Bytes-10                      11638             97786 ns/op         523.59 MB/s        4692 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_512_Bytes-10                28629             38245 ns/op        1338.74 MB/s        1729 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_512_Bytes-10                     11793            100183 ns/op         511.07 MB/s        4664 B/op         40 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_512_Bytes-10               5926            201641 ns/op         253.92 MB/s       13298 B/op         81 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/1_Pair,_4096_Bytes-10                      18460             64174 ns/op        6382.61 MB/s         420 B/op          4 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/2_Pair,_4096_Bytes-10                      18037             65905 ns/op        6215.04 MB/s         840 B/op          8 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/5_Pair,_4096_Bytes-10                       4564            261221 ns/op        1568.02 MB/s        4384 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/10_Pair,_4096_Bytes-10                      1936            570935 ns/op         717.42 MB/s       16935 B/op         42 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Half_CPU_Pair,_4096_Bytes-10                3948            274273 ns/op        1493.40 MB/s        4889 B/op         20 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/CPU_Pair,_4096_Bytes-10                     1976            566068 ns/op         723.59 MB/s       16478 B/op         42 allocs/op
BenchmarkAsyncThroughputNetworkMultiple/Double_CPU_Pair,_4096_Bytes-10               972           1158242 ns/op         353.64 MB/s       60079 B/op         88 allocs/op
BenchmarkThroughputClient/test-10                                                    100          10776258 ns/op        3113.69 MB/s        7136 B/op         14 allocs/op
BenchmarkThroughputResponseClient/test-10                                             97          11159139 ns/op        3006.86 MB/s       10357 B/op         27 allocs/op
BenchmarkThroughputServerSingle/test-10                                              100          10483248 ns/op        3200.72 MB/s        4959 B/op          3 allocs/op
BenchmarkThroughputServerUnlimited/test-10                                            33          35351692 ns/op         949.15 MB/s    10431952 B/op     146906 allocs/op
BenchmarkThroughputServerLimited/test-10                                              87         201330379 ns/op         166.66 MB/s     7253038 B/op     132657 allocs/op
BenchmarkThroughputResponseServerSingle/test-10                                      108          10953947 ns/op        3063.18 MB/s        7479 B/op         11 allocs/op
BenchmarkThroughputResponseServerSlowSingle/test-10                                    1        4501669542 ns/op           7.45 MB/s    37609072 B/op     261185 allocs/op
BenchmarkThroughputResponseServerSlowUnlimited/test-10                                34          37407554 ns/op         896.98 MB/s     7455075 B/op     133211 allocs/op
BenchmarkThroughputResponseServerSlowLimited/test-10                                  19          62998375 ns/op         532.62 MB/s     7163451 B/op     131105 allocs/op
BenchmarkSyncThroughputPipe/32_Bytes-10                                             8994            130804 ns/op          24.46 MB/s        1856 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/512_Bytes-10                                            8984            131410 ns/op         389.62 MB/s        1856 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/1024_Bytes-10                                           9048            131380 ns/op         779.42 MB/s        1856 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/2048_Bytes-10                                           8671            131456 ns/op        1557.94 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputPipe/4096_Bytes-10                                           8516            135246 ns/op        3028.55 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/32_Bytes-10                                          3867            312477 ns/op          10.24 MB/s        1856 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/512_Bytes-10                                         3114            338563 ns/op         151.23 MB/s        1856 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/1024_Bytes-10                                        3289            341366 ns/op         299.97 MB/s        1857 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/2048_Bytes-10                                        3356            346163 ns/op         591.63 MB/s        1859 B/op        204 allocs/op
BenchmarkSyncThroughputNetwork/4096_Bytes-10                                        3369            355739 ns/op        1151.40 MB/s        1856 B/op        204 allocs/op
BenchmarkAsyncThroughputLarge/1MB-10                                                 181           6501724 ns/op        16127.66 MB/s      18523 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/2MB-10                                                  88          13372155 ns/op        15682.98 MB/s     110069 B/op          4 allocs/op
BenchmarkAsyncThroughputLarge/4MB-10                                                  24          53477300 ns/op        7843.15 MB/s      533048 B/op          5 allocs/op
BenchmarkAsyncThroughputLarge/8MB-10                                                   9         111540301 ns/op        7520.70 MB/s     1879328 B/op          7 allocs/op
BenchmarkAsyncThroughputLarge/16MB-10                                                  5         242211842 ns/op        6926.67 MB/s     7432716 B/op          9 allocs/op
BenchmarkSyncThroughputLarge/1MB-10                                                   88          11811695 ns/op        8877.44 MB/s      240099 B/op        205 allocs/op
BenchmarkSyncThroughputLarge/2MB-10                                                   50          24872849 ns/op        8431.49 MB/s     1272776 B/op        208 allocs/op
BenchmarkSyncThroughputLarge/4MB-10                                                   22          53169602 ns/op        7888.54 MB/s     3839956 B/op        211 allocs/op
BenchmarkSyncThroughputLarge/8MB-10                                                   10         106845708 ns/op        7851.14 MB/s    12513327 B/op        217 allocs/op
BenchmarkSyncThroughputLarge/16MB-10                                                   5         229974883 ns/op        7295.24 MB/s        2035 B/op        206 allocs/op
BenchmarkTCPThroughput/32_Bytes-10                                                 22454             53398 ns/op          59.93 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/512_Bytes-10                                                14328             83769 ns/op         611.20 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1024_Bytes-10                                                9751            123262 ns/op         830.75 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/2048_Bytes-10                                                5888            208347 ns/op         982.98 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4096_Bytes-10                                                3130            387717 ns/op        1056.44 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/1MB-10                                                         84          12111463 ns/op        8657.72 MB/s         306 B/op          4 allocs/op
BenchmarkTCPThroughput/2MB-10                                                         61          24165389 ns/op        8678.33 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/4MB-10                                                         22          49378146 ns/op        8494.25 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/8MB-10                                                         10         102191079 ns/op        8208.75 MB/s         304 B/op          4 allocs/op
BenchmarkTCPThroughput/16MB-10                                                         5         224925100 ns/op        7459.02 MB/s         304 B/op          4 allocs/op
PASS
ok      github.com/loopholelabs/frisbee-go      152.626s
?       github.com/loopholelabs/frisbee-go/internal/dialer      [no test files]
goos: darwin
goarch: arm64
pkg: github.com/loopholelabs/frisbee-go/pkg/metadata
BenchmarkEncode-10              105045564               11.38 ns/op
BenchmarkDecode-10              345147318                3.476 ns/op
BenchmarkEncodeDecode-10        78343893                14.57 ns/op
PASS
ok      github.com/loopholelabs/frisbee-go/pkg/metadata 4.878s
PASS
ok      github.com/loopholelabs/frisbee-go/pkg/packet   0.107s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
