### PR TITLE
Feat: Simplifying Ping/Heartbeat semantics

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,3 +1,7 @@
 *out
 *logs
-external
+*actions
+*notifications
+*plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,14 +1,19 @@
 version: 0.1
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
 cli:
-  version: 0.15.1-beta
+  version: 0.18.0-beta
 lint:
   enabled:
-    - actionlint@1.6.13
-    - gitleaks@8.8.7
+    - git-diff-check@SYSTEM
+    - actionlint@1.6.19
+    - gitleaks@8.13.0
     - gofmt@1.18.3
-    - golangci-lint@1.46.2
-    - markdownlint@0.31.1
-    - prettier@2.6.2
+    - golangci-lint@1.49.0
+    - markdownlint@0.32.2
+    - prettier@2.7.1
   ignore:
     - linters: [ALL]
       paths:

--- a/async_test.go
+++ b/async_test.go
@@ -231,7 +231,7 @@ func TestAsyncReadClose(t *testing.T) {
 	err = readerConn.conn.Close()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(DefaultPingInterval * 2)
 
 	err = writerConn.WritePacket(p)
 	if err == nil {

--- a/conn.go
+++ b/conn.go
@@ -33,7 +33,8 @@ const DefaultBufferSize = 1 << 16
 var (
 	defaultLogger = zerolog.New(io.Discard)
 
-	DefaultDeadline = time.Second * 5
+	DefaultDeadline     = time.Second * 5
+	DefaultPingInterval = time.Millisecond * 500
 
 	emptyTime = time.Time{}
 	pastTime  = time.Unix(1, 0)

--- a/frisbee.go
+++ b/frisbee.go
@@ -59,15 +59,13 @@ type HandlerTable map[uint16]Handler
 
 // These are internal reserved packet types, and are the reason you cannot use 0-9 in Handler functions:
 const (
-	// HEARTBEAT is used to send heartbeats from the client to the server (and measure round trip time)
-	HEARTBEAT = uint16(iota)
-
 	// PING is used to check if a client is still alive
-	PING
+	PING = uint16(iota)
 
 	// PONG is used to respond to a PING packets
 	PONG
 
+	RESERVED2
 	RESERVED3
 	RESERVED4
 	RESERVED5
@@ -78,14 +76,6 @@ const (
 )
 
 var (
-	// HEARTBEATPacket is a pre-allocated Frisbee Packet for HEARTBEAT Packets
-	HEARTBEATPacket = &packet.Packet{
-		Metadata: &metadata.Metadata{
-			Operation: HEARTBEAT,
-		},
-		Content: polyglot.NewBuffer(),
-	}
-
 	// PINGPacket is a pre-allocated Frisbee Packet for PING Packets
 	PINGPacket = &packet.Packet{
 		Metadata: &metadata.Metadata{

--- a/options.go
+++ b/options.go
@@ -36,11 +36,9 @@ var DefaultLogger = zerolog.New(io.Discard)
 //	options := Options {
 //		KeepAlive: time.Minute * 3,
 //		Logger: &DefaultLogger,
-//		Heartbeat: time.Second * 5,
 //	}
 type Options struct {
 	KeepAlive time.Duration
-	Heartbeat time.Duration
 	Logger    *zerolog.Logger
 	TLSConfig *tls.Config
 }
@@ -57,10 +55,6 @@ func loadOptions(options ...Option) *Options {
 
 	if opts.KeepAlive == 0 {
 		opts.KeepAlive = time.Minute * 3
-	}
-
-	if opts.Heartbeat == 0 {
-		opts.Heartbeat = time.Second * 5
 	}
 
 	return opts
@@ -84,15 +78,6 @@ func WithKeepAlive(keepAlive time.Duration) Option {
 func WithLogger(logger *zerolog.Logger) Option {
 	return func(opts *Options) {
 		opts.Logger = logger
-	}
-}
-
-// WithHeartbeat sets the minimum time between heartbeat packets. By default, packets are only sent if
-// no packets have been sent since the last heartbeat packet - to change this behaviour you can disable heartbeats
-// (by passing in -1), and implementing your own logic.
-func WithHeartbeat(heartbeat time.Duration) Option {
-	return func(opts *Options) {
-		opts.Heartbeat = heartbeat
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -31,7 +31,6 @@ func TestWithoutOptions(t *testing.T) {
 	options := loadOptions()
 
 	assert.Equal(t, time.Minute*3, options.KeepAlive)
-	assert.Equal(t, time.Second*5, options.Heartbeat)
 	assert.Equal(t, &DefaultLogger, options.Logger)
 	assert.Nil(t, options.TLSConfig)
 }
@@ -41,7 +40,6 @@ func TestWithOptions(t *testing.T) {
 
 	option := WithOptions(Options{
 		KeepAlive: time.Minute * 6,
-		Heartbeat: time.Second * 60,
 		Logger:    nil,
 		TLSConfig: &tls.Config{},
 	})
@@ -49,7 +47,6 @@ func TestWithOptions(t *testing.T) {
 	options := loadOptions(option)
 
 	assert.Equal(t, time.Minute*6, options.KeepAlive)
-	assert.Equal(t, time.Second*60, options.Heartbeat)
 	assert.Equal(t, &DefaultLogger, options.Logger)
 	assert.Equal(t, &tls.Config{}, options.TLSConfig)
 }
@@ -59,13 +56,11 @@ func TestDisableOptions(t *testing.T) {
 
 	option := WithOptions(Options{
 		KeepAlive: -1,
-		Heartbeat: -1,
 	})
 
 	options := loadOptions(option)
 
 	assert.Equal(t, time.Duration(-1), options.KeepAlive)
-	assert.Equal(t, time.Duration(-1), options.Heartbeat)
 	assert.Equal(t, &DefaultLogger, options.Logger)
 	assert.Nil(t, options.TLSConfig)
 }
@@ -79,14 +74,12 @@ func TestIndividualOptions(t *testing.T) {
 	}
 
 	keepAliveOption := WithKeepAlive(time.Minute * 6)
-	heartbeatOption := WithHeartbeat(time.Second * 60)
 	loggerOption := WithLogger(&logger)
 	TLSOption := WithTLS(tlsConfig)
 
-	options := loadOptions(keepAliveOption, loggerOption, heartbeatOption, TLSOption)
+	options := loadOptions(keepAliveOption, loggerOption, TLSOption)
 
 	assert.Equal(t, time.Minute*6, options.KeepAlive)
-	assert.Equal(t, time.Second*60, options.Heartbeat)
 	assert.Equal(t, &logger, options.Logger)
 	assert.Equal(t, tlsConfig, options.TLSConfig)
 }

--- a/server.go
+++ b/server.go
@@ -132,13 +132,6 @@ func (s *Server) SetHandlerTable(handlerTable HandlerTable) error {
 		}
 	}
 
-	if s.options.Heartbeat > time.Duration(0) {
-		handlerTable[HEARTBEAT] = func(_ context.Context, incoming *packet.Packet) (outgoing *packet.Packet, action Action) {
-			outgoing = incoming
-			return
-		}
-	}
-
 	s.handlerTable = handlerTable
 	return nil
 }

--- a/sync.go
+++ b/sync.go
@@ -122,7 +122,7 @@ func (c *Sync) Handshake() error {
 // if the connection is not *tls.Conn then the NotTLSConnectionError is returned
 func (c *Sync) HandshakeContext(ctx context.Context) error {
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
-		return tlsConn.HandshakeContext(ctx) //trunk-ignore(golangci-lint/typecheck)
+		return tlsConn.HandshakeContext(ctx)
 	}
 	return NotTLSConnectionError
 }


### PR DESCRIPTION
## Description

Frisbee currently has a very complex timeout mechanism for heartbeats that adds a lot of complexity and processing overhead that doesn't really need to be there. 

The current logic is to wait for a connection read to timeout and then send a PING Packet and start a goroutine to watch for a PONG packet - then unblock the read goroutine and continue like normal. Then when a PONG packet is received, clear the ping timer and exit the started goroutine - otherwise if the PONG packet is not received in time, the goroutine will kill the connection. 

This is inefficient for many reasons but most importantly because the frisbee client ALSO runs a heartbeat goroutine that sends a heartbeat packet to the server periodically but only if the buffer is empty. 

This PR simplifies the whole process by a lot - now, a persistent goroutine called the `pingLoop` is created that periodically sends a `PINGPacket`. It does not have to wait to receive a response because a read deadline is added to the connection before every read call - and the read deadline is significantly longer than the ping time. 

This PR also changes when write deadlines and read deadlines are called to make them more consistent and to close some error cases. 

The most important part about this PR is that it will make it significantly easier to implement Frisbee in a different language. 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
