### PR TITLE
Feat: Adding custom listener with `StartWithListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v0.7.1] - 2022-12-01
 
+### Features
+
+- Added `StartWithListener` function to start a server with a custom listener ([#155](https://github.com/loopholelabs/frisbee-go/issues/155))
+
 ### Fixes
 
 - StreamHandlers would not be registered when calling `ServeConn` because they were created during a `server.Start`


### PR DESCRIPTION
## Description

This PR allows users to add a custom listener to start frisbee servers.

Fixes #155 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have signed-off my commits with `git commit -s` (see [the developer's certificate of origin](https://github.com/apps/dco))