### PR TITLE
feat: Utilize Context-Aware Subloggers

### DIFF
--- a/async.go
+++ b/async.go
@@ -77,11 +77,12 @@ func NewAsync(c net.Conn, logger types.Logger, streamHandler ...NewStreamHandler
 		flushCh:  make(chan struct{}, 3),
 		closeCh:  make(chan struct{}),
 		streams:  make(map[uint16]*Stream),
-		logger:   logger,
 	}
 
 	if logger == nil {
 		conn.logger = noop.New(types.InfoLevel)
+	} else {
+		logger.SubLogger("async").With().Str("remote", c.RemoteAddr().String()).Logger()
 	}
 
 	if len(streamHandler) > 0 {

--- a/client.go
+++ b/client.go
@@ -44,6 +44,8 @@ func NewClient(handlerTable HandlerTable, ctx context.Context, opts ...Option) (
 	options := loadOptions(opts...)
 	var heartbeatChannel chan struct{}
 
+	options.Logger = options.Logger.SubLogger("client")
+
 	return &Client{
 		handlerTable:     handlerTable,
 		ctx:              ctx,

--- a/options.go
+++ b/options.go
@@ -35,6 +35,8 @@ func loadOptions(options ...Option) *Options {
 
 	if opts.Logger == nil {
 		opts.Logger = noop.New(types.InfoLevel)
+	} else {
+		opts.Logger = opts.Logger.SubLogger("frisbee")
 	}
 
 	if opts.KeepAlive == 0 {

--- a/server.go
+++ b/server.go
@@ -77,6 +77,9 @@ type Server struct {
 // The Start method must then be called to start the server and listen for connections.
 func NewServer(handlerTable HandlerTable, opts ...Option) (*Server, error) {
 	options := loadOptions(opts...)
+
+	options.Logger = options.Logger.SubLogger("server")
+
 	s := &Server{
 		options:       options,
 		connections:   make(map[*Async]struct{}),

--- a/sync.go
+++ b/sync.go
@@ -61,13 +61,15 @@ func ConnectSync(addr string, keepAlive time.Duration, logger types.Logger, TLSC
 // NewSync takes an existing net.Conn object and wraps it in a frisbee connection
 func NewSync(c net.Conn, logger types.Logger) (conn *Sync) {
 	conn = &Sync{
-		conn:   c,
-		logger: logger,
+		conn: c,
 	}
 
 	if logger == nil {
 		conn.logger = noop.New(types.InfoLevel)
+	} else {
+		conn.logger = logger.SubLogger("sync").With().Str("remote", c.RemoteAddr().String()).Logger()
 	}
+
 	return
 }
 


### PR DESCRIPTION
This PR updates the logging functionality throughout frisbee to add context to all logging messages that specify what package is being utilized (client, server, sync, async, etc.) as well as any connection-specific context (ie. remote addresses)