### PR TITLE
Bug: Fixing Deadlock on Connection Close

### DIFF
--- a/async.go
+++ b/async.go
@@ -402,7 +402,7 @@ func (c *Async) close() error {
 		c.stale = c.incoming.Drain()
 		c.staleMu.Unlock()
 		for _, stream := range c.streams {
-			_ = stream.Close()
+			_ = stream.closeSend(false)
 		}
 		c.streamsMu.Unlock()
 		c.Lock()

--- a/stream_test.go
+++ b/stream_test.go
@@ -213,3 +213,56 @@ func TestNewStreamDualCreate(t *testing.T) {
 	err = readerConn.Close()
 	assert.NoError(t, err)
 }
+
+func TestStreamConnClose(t *testing.T) {
+	t.Parallel()
+
+	const packetSize = 512
+
+	emptyLogger := logging.Test(t, logging.Noop, t.Name())
+
+	reader, writer := net.Pipe()
+
+	readerConn := NewAsync(reader, emptyLogger, func(_ *Stream) {})
+	writerConn := NewAsync(writer, emptyLogger, func(_ *Stream) {})
+
+	writerStream := writerConn.NewStream(0)
+	readerStream := readerConn.NewStream(0)
+
+	data := make([]byte, packetSize)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	p := packet.Get()
+	p.Metadata.Id = 64
+	p.Metadata.Operation = 32
+	p.Metadata.ContentLength = uint32(packetSize)
+	p.Content.Write(data)
+
+	err = writerStream.WritePacket(p)
+	require.NoError(t, err)
+
+	packet.Put(p)
+
+	err = writerConn.Close()
+	require.NoError(t, err)
+
+	time.Sleep(DefaultDeadline)
+
+	err = writerStream.Close()
+	require.ErrorIs(t, err, StreamClosed)
+
+	p, err = readerStream.ReadPacket()
+	require.NoError(t, err)
+	require.NotNil(t, p.Metadata)
+	assert.Equal(t, readerStream.ID(), p.Metadata.Id)
+	assert.Equal(t, STREAM, p.Metadata.Operation)
+	assert.Equal(t, uint32(packetSize), p.Metadata.ContentLength)
+	assert.Equal(t, data, p.Content.Bytes())
+
+	_, err = readerStream.ReadPacket()
+	require.ErrorIs(t, err, StreamClosed)
+
+	err = readerConn.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
 This PR fixes a deadlock that would occur if the connection was closed before its streams were. 
 
 It also adds an additional test case to avoid regressions. 