### PR TITLE
feat: context-managed streams

### DIFF
--- a/async.go
+++ b/async.go
@@ -84,13 +84,17 @@ func NewAsync(c net.Conn, logger types.Logger, streamHandler ...NewStreamHandler
 		conn.logger = noop.New(types.InfoLevel)
 	}
 
-	if len(streamHandler) > 0 {
+	if len(streamHandler) > 0 && streamHandler[0] != nil {
 		conn.newStreamHandler = streamHandler[0]
 	}
 
-	conn.wg.Add(3)
+	conn.wg.Add(1)
 	go conn.flushLoop()
+
+	conn.wg.Add(1)
 	go conn.readLoop()
+
+	conn.wg.Add(1)
 	go conn.pingLoop()
 
 	return

--- a/client_test.go
+++ b/client_test.go
@@ -49,7 +49,7 @@ func TestClientRaw(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(1)
@@ -144,7 +144,7 @@ func TestClientStaleClose(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(1)
@@ -204,7 +204,7 @@ func BenchmarkThroughputClient(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func BenchmarkThroughputResponseClient(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/server.go
+++ b/server.go
@@ -16,15 +16,12 @@ import (
 )
 
 var (
-	BaseContextNil = errors.New("BaseContext function cannot be nil")
-	OnClosedNil    = errors.New("OnClosed function cannot be nil")
-	PreWriteNil    = errors.New("PreWrite function cannot be nil")
-	ListenerNil    = errors.New("listener cannot be nil")
+	OnClosedNil = errors.New("OnClosed function cannot be nil")
+	PreWriteNil = errors.New("PreWrite function cannot be nil")
+	ListenerNil = errors.New("listener cannot be nil")
 )
 
 var (
-	defaultBaseContext = context.Background
-
 	defaultOnClosed = func(_ *Async, _ error) {}
 
 	defaultPreWrite = func() {}
@@ -47,8 +44,8 @@ type Server struct {
 	concurrency   uint64
 	limiter       chan struct{}
 
-	// baseContext is used to define the base context for this Server and all incoming connections
-	baseContext func() context.Context
+	baseContext       context.Context
+	baseContextCancel context.CancelFunc
 
 	// onClosed is a function run by the server whenever a connection is closed
 	onClosed func(*Async, error)
@@ -78,28 +75,23 @@ type Server struct {
 
 // NewServer returns an uninitialized frisbee Server with the registered HandlerTable.
 // The Start method must then be called to start the server and listen for connections.
-func NewServer(handlerTable HandlerTable, opts ...Option) (*Server, error) {
+func NewServer(handlerTable HandlerTable, ctx context.Context, opts ...Option) (*Server, error) {
 	options := loadOptions(opts...)
+
+	baseContext, baseContextCancel := context.WithCancel(ctx)
+
 	s := &Server{
-		options:       options,
-		connections:   make(map[*Async]struct{}),
-		startedCh:     make(chan struct{}),
-		baseContext:   defaultBaseContext,
-		onClosed:      defaultOnClosed,
-		preWrite:      defaultPreWrite,
-		streamHandler: defaultStreamHandler,
+		options:           options,
+		connections:       make(map[*Async]struct{}),
+		startedCh:         make(chan struct{}),
+		baseContext:       baseContext,
+		baseContextCancel: baseContextCancel,
+		onClosed:          defaultOnClosed,
+		preWrite:          defaultPreWrite,
+		streamHandler:     defaultStreamHandler,
 	}
 
 	return s, s.SetHandlerTable(handlerTable)
-}
-
-// SetBaseContext sets the baseContext function for the server. If f is nil, it returns an error.
-func (s *Server) SetBaseContext(f func() context.Context) error {
-	if f == nil {
-		return BaseContextNil
-	}
-	s.baseContext = f
-	return nil
 }
 
 // SetOnClosed sets the onClosed function for the server. If f is nil, it returns an error.
@@ -123,7 +115,7 @@ func (s *Server) SetPreWrite(f func()) error {
 // SetStreamHandler sets the streamHandler function for the server.
 func (s *Server) SetStreamHandler(f func(context.Context, *Stream)) error {
 	s.streamHandler = func(stream *Stream) {
-		streamCtx := s.baseContext()
+		streamCtx := s.baseContext
 		if s.StreamContext != nil {
 			streamCtx = s.StreamContext(streamCtx, stream)
 		}
@@ -437,7 +429,7 @@ func (s *Server) serveConn(newConn net.Conn) {
 	}
 
 	frisbeeConn := NewAsync(newConn, s.Logger(), s.streamHandler)
-	connCtx := s.baseContext()
+	connCtx := s.baseContext
 	s.connectionsMu.Lock()
 	if s.shutdown.Load() {
 		s.wg.Done()
@@ -471,16 +463,18 @@ func (s *Server) Logger() types.Logger {
 
 // Shutdown shuts down the frisbee server and kills all the goroutines and active connections
 func (s *Server) Shutdown() error {
-	s.shutdown.Store(true)
-	s.connectionsMu.Lock()
-	for c := range s.connections {
-		_ = c.Close()
-		delete(s.connections, c)
-	}
-	s.connectionsMu.Unlock()
-	defer s.wg.Wait()
-	if s.listener != nil {
-		return s.listener.Close()
+	if s.shutdown.CompareAndSwap(false, true) {
+		s.baseContextCancel()
+		s.connectionsMu.Lock()
+		for c := range s.connections {
+			_ = c.Close()
+			delete(s.connections, c)
+		}
+		s.connectionsMu.Unlock()
+		defer s.wg.Wait()
+		if s.listener != nil {
+			return s.listener.Close()
+		}
 	}
 	return nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -54,7 +54,7 @@ func TestServerRawSingle(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(1)
@@ -155,7 +155,7 @@ func TestServerStaleCloseSingle(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(1)
@@ -229,7 +229,7 @@ func TestServerMultipleConnectionsSingle(t *testing.T) {
 		}
 
 		emptyLogger := logging.Test(t, logging.Noop, t.Name())
-		s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+		s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 		require.NoError(t, err)
 
 		s.SetConcurrency(1)
@@ -329,7 +329,7 @@ func TestServerRawUnlimited(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(0)
@@ -432,7 +432,7 @@ func TestServerStaleCloseUnlimited(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(0)
@@ -509,7 +509,7 @@ func TestServerMultipleConnectionsUnlimited(t *testing.T) {
 		}
 
 		emptyLogger := logging.Test(t, logging.Noop, t.Name())
-		s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+		s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 		require.NoError(t, err)
 
 		s.SetConcurrency(0)
@@ -609,7 +609,7 @@ func TestServerRawLimited(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(10)
@@ -712,7 +712,7 @@ func TestServerStaleCloseLimited(t *testing.T) {
 	}
 
 	emptyLogger := logging.Test(t, logging.Noop, t.Name())
-	s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+	s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 	require.NoError(t, err)
 
 	s.SetConcurrency(10)
@@ -790,7 +790,7 @@ func TestServerMultipleConnectionsLimited(t *testing.T) {
 		}
 
 		emptyLogger := logging.Test(t, logging.Noop, t.Name())
-		s, err := NewServer(serverHandlerTable, WithLogger(emptyLogger))
+		s, err := NewServer(serverHandlerTable, context.Background(), WithLogger(emptyLogger))
 		require.NoError(t, err)
 
 		s.SetConcurrency(10)
@@ -874,7 +874,7 @@ func BenchmarkThroughputServerSingle(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -938,7 +938,7 @@ func BenchmarkThroughputServerUnlimited(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1002,7 +1002,7 @@ func BenchmarkThroughputServerLimited(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1076,7 +1076,7 @@ func BenchmarkThroughputResponseServerSingle(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1161,7 +1161,7 @@ func BenchmarkThroughputResponseServerSlowSingle(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1248,7 +1248,7 @@ func BenchmarkThroughputResponseServerSlowUnlimited(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1336,7 +1336,7 @@ func BenchmarkThroughputResponseServerSlowLimited(b *testing.B) {
 	}
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
-	server, err := NewServer(handlerTable, WithLogger(emptyLogger))
+	server, err := NewServer(handlerTable, context.Background(), WithLogger(emptyLogger))
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
This PR creates some very breaking changes, but brings the overall implementation of the frisbee client and server inline with what one would expect, while filling some gaps in our implementation with regards to thread safety.
 
The firs thing this PR does is modifies stream management within the context of a server or client to properly make use of the base context for a server or client when handling new streams - this means the `SetStreamHandler` functions of both the client and the server now accept a context. This context will also now automatically be cancelled if the client or server is closed (or if the underlying client connection is ever closed). 

This PR also adds a new `StreamContext` option that allows user to override how contexts for streams get created, as well as what values they contain. 

The main breaking change this PR makes is it removes the `BaseContext` function in the server, and instead sets a static `baseContext` context that the user can pass in at runtime. This context is used to cancel handler goroutines and not used to kill the server or client itself. 

What's important to note is that this change is necessary if we want the death of a client or server to also cancel the context. 