### PR TITLE
Improve handling of unexpected packets

### DIFF
--- a/async.go
+++ b/async.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -299,6 +300,7 @@ func (c *Async) writePacket(p *packet.Packet, closeOnErr bool) error {
 	}
 
 	encodedMetadata := metadata.GetBuffer()
+	binary.BigEndian.PutUint16(encodedMetadata[metadata.MagicOffset:metadata.MagicOffset+metadata.MagicSize], metadata.PacketMagicHeader)
 	binary.BigEndian.PutUint16(encodedMetadata[metadata.IdOffset:metadata.IdOffset+metadata.IdSize], p.Metadata.Id)
 	binary.BigEndian.PutUint16(encodedMetadata[metadata.OperationOffset:metadata.OperationOffset+metadata.OperationSize], p.Metadata.Operation)
 	binary.BigEndian.PutUint32(encodedMetadata[metadata.ContentLengthOffset:metadata.ContentLengthOffset+metadata.ContentLengthSize], p.Metadata.ContentLength)
@@ -514,10 +516,18 @@ func (c *Async) readLoop() {
 		index = 0
 		for index < n {
 			p := packet.Get()
+			p.Metadata.Magic = binary.BigEndian.Uint16(buf[index+metadata.MagicOffset : index+metadata.MagicOffset+metadata.MagicSize])
 			p.Metadata.Id = binary.BigEndian.Uint16(buf[index+metadata.IdOffset : index+metadata.IdOffset+metadata.IdSize])
 			p.Metadata.Operation = binary.BigEndian.Uint16(buf[index+metadata.OperationOffset : index+metadata.OperationOffset+metadata.OperationSize])
 			p.Metadata.ContentLength = binary.BigEndian.Uint32(buf[index+metadata.ContentLengthOffset : index+metadata.ContentLengthOffset+metadata.ContentLengthSize])
 			index += metadata.Size
+
+			if p.Metadata.Magic != metadata.PacketMagicHeader {
+				c.Logger().Debug().Str("magic", fmt.Sprintf("0x%04x", p.Metadata.Magic)).Msg("received packet with incorrect magic header")
+				c.wg.Done()
+				_ = c.closeWithError(InvalidMagicHeader)
+				return
+			}
 
 			switch p.Metadata.Operation {
 			case PING:

--- a/async_test.go
+++ b/async_test.go
@@ -175,10 +175,7 @@ func TestAsyncLargeRead(t *testing.T) {
 func TestAsyncDisableMaxContentLength(t *testing.T) {
 	// Don't run in parallel since it modifies DefaultMaxContentLength.
 
-	oldMax := DefaultMaxContentLength
-	DefaultMaxContentLength = 0
-	t.Cleanup(func() { DefaultMaxContentLength = oldMax })
-
+	oldMax := DisableMaxContentLength(t)
 	logger := logging.Test(t, logging.Noop, t.Name())
 
 	t.Run("read", func(t *testing.T) {
@@ -566,6 +563,8 @@ func TestAsyncTimeout(t *testing.T) {
 }
 
 func BenchmarkAsyncThroughputPipe(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
@@ -586,6 +585,8 @@ func BenchmarkAsyncThroughputPipe(b *testing.B) {
 }
 
 func BenchmarkAsyncThroughputNetwork(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
@@ -609,6 +610,8 @@ func BenchmarkAsyncThroughputNetwork(b *testing.B) {
 }
 
 func BenchmarkAsyncThroughputNetworkMultiple(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	throughputRunner := func(testSize uint32, packetSize uint32, readerConn Conn, writerConn Conn) func(b *testing.B) {

--- a/client_test.go
+++ b/client_test.go
@@ -189,6 +189,8 @@ func TestClientStaleClose(t *testing.T) {
 }
 
 func BenchmarkThroughputClient(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -263,6 +265,8 @@ func BenchmarkThroughputClient(b *testing.B) {
 }
 
 func BenchmarkThroughputResponseClient(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 

--- a/conn.go
+++ b/conn.go
@@ -18,8 +18,9 @@ import (
 const DefaultBufferSize = 1 << 16
 
 var (
-	DefaultDeadline     = time.Second * 5
-	DefaultPingInterval = time.Millisecond * 500
+	DefaultDeadline         = time.Second * 5
+	DefaultPingInterval     = time.Millisecond * 500
+	DefaultMaxContentLength = uint32(5 * 1024 * 1024) // 5 MB
 
 	emptyTime = time.Time{}
 	pastTime  = time.Unix(1, 0)

--- a/frisbee.go
+++ b/frisbee.go
@@ -24,6 +24,7 @@ var (
 	InvalidBufferLength      = errors.New("invalid buffer length")
 	InvalidHandlerTable      = errors.New("invalid handler table configuration, a reserved value may have been used")
 	InvalidOperation         = errors.New("invalid operation in packet, a reserved value may have been used")
+	ContentLengthExceeded    = errors.New("content length exceeds maximum allowed")
 )
 
 // Action is an ENUM used to modify the state of the client or server from a Handler function

--- a/frisbee.go
+++ b/frisbee.go
@@ -20,6 +20,7 @@ var (
 	StreamClosed             = errors.New("stream closed")
 	InvalidStreamPacket      = errors.New("invalid stream packet")
 	ConnectionNotInitialized = errors.New("connection not initialized")
+	InvalidMagicHeader       = errors.New("invalid magic header")
 	InvalidBufferLength      = errors.New("invalid buffer length")
 	InvalidHandlerTable      = errors.New("invalid handler table configuration, a reserved value may have been used")
 	InvalidOperation         = errors.New("invalid operation in packet, a reserved value may have been used")

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -14,6 +14,7 @@ func TestMessageEncodeDecode(t *testing.T) {
 	t.Parallel()
 
 	message := &Metadata{
+		Magic:         PacketMagicHeader,
 		Id:            uint16(64),
 		Operation:     PacketProbe,
 		ContentLength: uint32(0),
@@ -21,6 +22,7 @@ func TestMessageEncodeDecode(t *testing.T) {
 
 	correct := NewBuffer()
 
+	binary.BigEndian.PutUint16(correct[MagicOffset:MagicOffset+MagicSize], PacketMagicHeader)
 	binary.BigEndian.PutUint16(correct[IdOffset:IdOffset+IdSize], uint16(64))
 	binary.BigEndian.PutUint16(correct[OperationOffset:OperationOffset+OperationSize], PacketProbe)
 	binary.BigEndian.PutUint32(correct[ContentLengthOffset:ContentLengthOffset+ContentLengthSize], uint32(0))
@@ -44,6 +46,7 @@ func TestEncodeDecode(t *testing.T) {
 
 	message, err := Decode(encodedBytes[:])
 	require.NoError(t, err)
+	assert.Equal(t, PacketMagicHeader, message.Magic)
 	assert.Equal(t, uint32(512), message.ContentLength)
 	assert.Equal(t, uint16(64), message.Id)
 	assert.Equal(t, PacketPong, message.Operation)
@@ -53,6 +56,7 @@ func TestEncodeDecode(t *testing.T) {
 
 	emptyMessage, err := Decode(emptyEncodedBytes[:])
 	require.NoError(t, err)
+	assert.Equal(t, PacketMagicHeader, message.Magic)
 	assert.Equal(t, uint32(0), emptyMessage.ContentLength)
 	assert.Equal(t, uint16(64), emptyMessage.Id)
 	assert.Equal(t, PacketPing, emptyMessage.Operation)

--- a/pkg/packet/packet.go
+++ b/pkg/packet/packet.go
@@ -12,6 +12,7 @@ import (
 //
 //	type Packet struct {
 //		Metadata struct {
+//			Magic         uint16 // 2 Bytes
 //			Id            uint16 // 2 Bytes
 //			Operation     uint16 // 2 Bytes
 //			ContentLength uint32 // 4 Bytes
@@ -27,6 +28,7 @@ type Packet struct {
 }
 
 func (p *Packet) Reset() {
+	p.Metadata.Magic = 0
 	p.Metadata.Id = 0
 	p.Metadata.Operation = 0
 	p.Metadata.ContentLength = 0

--- a/pkg/packet/packet_test.go
+++ b/pkg/packet/packet_test.go
@@ -16,6 +16,7 @@ func TestNew(t *testing.T) {
 
 	assert.IsType(t, new(Packet), p)
 	assert.NotNil(t, p.Metadata)
+	assert.Equal(t, uint16(0), p.Metadata.Magic)
 	assert.Equal(t, uint16(0), p.Metadata.Id)
 	assert.Equal(t, uint16(0), p.Metadata.Operation)
 	assert.Equal(t, uint32(0), p.Metadata.ContentLength)

--- a/server_test.go
+++ b/server_test.go
@@ -892,6 +892,8 @@ func TestServerInvalidPacket(t *testing.T) {
 }
 
 func BenchmarkThroughputServerSingle(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -955,6 +957,8 @@ func BenchmarkThroughputServerSingle(b *testing.B) {
 }
 
 func BenchmarkThroughputServerUnlimited(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -1019,6 +1023,8 @@ func BenchmarkThroughputServerUnlimited(b *testing.B) {
 }
 
 func BenchmarkThroughputServerLimited(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -1083,6 +1089,8 @@ func BenchmarkThroughputServerLimited(b *testing.B) {
 }
 
 func BenchmarkThroughputResponseServerSingle(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -1167,6 +1175,8 @@ func BenchmarkThroughputResponseServerSingle(b *testing.B) {
 }
 
 func BenchmarkThroughputResponseServerSlowSingle(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -1252,6 +1262,8 @@ func BenchmarkThroughputResponseServerSlowSingle(b *testing.B) {
 }
 
 func BenchmarkThroughputResponseServerSlowUnlimited(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 
@@ -1340,6 +1352,8 @@ func BenchmarkThroughputResponseServerSlowUnlimited(b *testing.B) {
 }
 
 func BenchmarkThroughputResponseServerSlowLimited(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 1<<16 - 1
 	const packetSize = 512
 

--- a/sync_test.go
+++ b/sync_test.go
@@ -185,7 +185,7 @@ func TestSyncLargeRead(t *testing.T) {
 	go func() {
 		defer close(doneCh)
 
-		_, err = client.Write(bigData)
+		_, err := client.Write(bigData)
 
 		// Verify client was disconnected.
 		var opError *net.OpError
@@ -202,10 +202,7 @@ func TestSyncLargeRead(t *testing.T) {
 func TestSyncDisableMaxContentLength(t *testing.T) {
 	// Don't run in parallel since it modifies DefaultMaxContentLength.
 
-	oldMax := DefaultMaxContentLength
-	DefaultMaxContentLength = 0
-	t.Cleanup(func() { DefaultMaxContentLength = oldMax })
-
+	oldMax := DisableMaxContentLength(t)
 	logger := logging.Test(t, logging.Noop, t.Name())
 
 	t.Run("read", func(t *testing.T) {
@@ -479,6 +476,8 @@ func TestSyncWriteClose(t *testing.T) {
 }
 
 func BenchmarkSyncThroughputPipe(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
@@ -499,6 +498,8 @@ func BenchmarkSyncThroughputPipe(b *testing.B) {
 }
 
 func BenchmarkSyncThroughputNetwork(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())

--- a/sync_test.go
+++ b/sync_test.go
@@ -225,6 +225,27 @@ func TestSyncRawConn(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSyncInvalid(t *testing.T) {
+	t.Parallel()
+
+	client, server, err := pair.New()
+	require.NoError(t, err)
+
+	serverConn := NewSync(server, logging.Test(t, logging.Noop, t.Name()))
+	t.Cleanup(func() { serverConn.Close() })
+
+	httpReq := []byte(`GET / HTTP/1.1
+Host: www.example.com
+User-Agent: curl/8.9.1
+Accept: */*`)
+	_, err = client.Write(httpReq)
+	assert.NoError(t, err)
+
+	_, err = serverConn.ReadPacket()
+	assert.ErrorIs(t, err, InvalidMagicHeader)
+	assert.ErrorIs(t, serverConn.Error(), InvalidMagicHeader)
+}
+
 func TestSyncReadClose(t *testing.T) {
 	t.Parallel()
 

--- a/sync_test.go
+++ b/sync_test.go
@@ -4,6 +4,7 @@ package frisbee
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"io"
 	"net"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/loopholelabs/polyglot/v2"
 	"github.com/loopholelabs/testing/conn/pair"
 
+	"github.com/loopholelabs/frisbee-go/pkg/metadata"
 	"github.com/loopholelabs/frisbee-go/pkg/packet"
 )
 
@@ -143,10 +145,140 @@ func TestSyncLargeWrite(t *testing.T) {
 
 	packet.Put(p)
 
-	err := readerConn.Close()
+	// Verify large writes past max length fails.
+	big := make([]byte, 2*DefaultMaxContentLength)
+
+	p = packet.Get()
+	p.Metadata.Id = 64
+	p.Metadata.Operation = 32
+	p.Metadata.ContentLength = uint32(len(big))
+	p.Content.Write(big)
+
+	err := writerConn.WritePacket(p)
+	assert.ErrorIs(t, err, ContentLengthExceeded)
+	p.Content.Reset()
+	packet.Put(p)
+
+	err = readerConn.Close()
 	assert.NoError(t, err)
 	err = writerConn.Close()
 	assert.NoError(t, err)
+}
+
+func TestSyncLargeRead(t *testing.T) {
+	t.Parallel()
+
+	client, server, err := pair.New()
+	require.NoError(t, err)
+
+	serverConn := NewSync(server, logging.Test(t, logging.Noop, t.Name()))
+	t.Cleanup(func() { serverConn.Close() })
+
+	// Write a large packet that exceeds the maximum limit.
+	bigData := make([]byte, 2*DefaultMaxContentLength+metadata.Size)
+	binary.BigEndian.PutUint16(bigData[metadata.MagicOffset:metadata.MagicOffset+metadata.MagicSize], metadata.PacketMagicHeader)
+	binary.BigEndian.PutUint16(bigData[metadata.IdOffset:metadata.IdOffset+metadata.IdSize], 0xFFFF)
+	binary.BigEndian.PutUint16(bigData[metadata.OperationOffset:metadata.OperationOffset+metadata.OperationSize], 0xFFFF)
+	binary.BigEndian.PutUint32(bigData[metadata.ContentLengthOffset:metadata.ContentLengthOffset+metadata.ContentLengthSize], 2*DefaultMaxContentLength)
+
+	doneCh := make(chan any)
+	go func() {
+		defer close(doneCh)
+
+		_, err = client.Write(bigData)
+
+		// Verify client was disconnected.
+		var opError *net.OpError
+		assert.ErrorAs(t, err, &opError)
+	}()
+
+	// Read packet and very it failed.
+	_, err = serverConn.ReadPacket()
+	assert.ErrorIs(t, err, ContentLengthExceeded)
+
+	<-doneCh
+}
+
+func TestSyncDisableMaxContentLength(t *testing.T) {
+	// Don't run in parallel since it modifies DefaultMaxContentLength.
+
+	oldMax := DefaultMaxContentLength
+	DefaultMaxContentLength = 0
+	t.Cleanup(func() { DefaultMaxContentLength = oldMax })
+
+	logger := logging.Test(t, logging.Noop, t.Name())
+
+	t.Run("read", func(t *testing.T) {
+		client, server, err := pair.New()
+		require.NoError(t, err)
+
+		serverConn := NewSync(server, logger)
+		t.Cleanup(func() { serverConn.Close() })
+
+		// Write a large packet that would exceed the default maximum limit.
+		content := make([]byte, 2*oldMax+metadata.Size)
+		binary.BigEndian.PutUint16(content[metadata.MagicOffset:metadata.MagicOffset+metadata.MagicSize], metadata.PacketMagicHeader)
+		binary.BigEndian.PutUint16(content[metadata.IdOffset:metadata.IdOffset+metadata.IdSize], 0xFFFF)
+		binary.BigEndian.PutUint16(content[metadata.OperationOffset:metadata.OperationOffset+metadata.OperationSize], 0xFFFF)
+		binary.BigEndian.PutUint32(content[metadata.ContentLengthOffset:metadata.ContentLengthOffset+metadata.ContentLengthSize], 2*oldMax)
+
+		doneCh := make(chan any)
+		go func() {
+			defer close(doneCh)
+
+			n, err := client.Write(content)
+			assert.NoError(t, err)
+			assert.Equal(t, int(2*oldMax+metadata.Size), n)
+		}()
+
+		// Verify packet can be read.
+		p, err := serverConn.ReadPacket()
+		assert.NoError(t, err)
+		assert.Equal(t, int(2*oldMax), p.Content.Len())
+
+		<-doneCh
+	})
+
+	t.Run("write", func(t *testing.T) {
+		client, server, err := pair.New()
+		require.NoError(t, err)
+
+		clientConn := NewSync(client, logger)
+		t.Cleanup(func() { clientConn.Close() })
+
+		serverConn := NewSync(server, logger)
+		t.Cleanup(func() { serverConn.Close() })
+
+		doneCh := make(chan any)
+		go func() {
+			defer close(doneCh)
+
+			p, err := serverConn.ReadPacket()
+			assert.NoError(t, err)
+			if err == nil {
+				assert.Equal(t, int(2*oldMax), p.Content.Len())
+			}
+		}()
+
+		p := packet.Get()
+		t.Cleanup(func() {
+			p.Content.Reset()
+			packet.Put(p)
+		})
+
+		// Write a large packet that would exceed the default maximum limit.
+		content := make([]byte, 2*oldMax)
+
+		p.Metadata.Id = 64
+		p.Metadata.Operation = 32
+		p.Metadata.ContentLength = uint32(len(content))
+		p.Content.Write(content)
+
+		err = clientConn.WritePacket(p)
+		require.NoError(t, err)
+
+		<-doneCh
+	})
 }
 
 func TestSyncRawConn(t *testing.T) {

--- a/testutil.go
+++ b/testutil.go
@@ -1,0 +1,13 @@
+package frisbee
+
+import "testing"
+
+func DisableMaxContentLength(tb testing.TB) uint32 {
+	tb.Helper()
+
+	oldMax := DefaultMaxContentLength
+	DefaultMaxContentLength = 0
+	tb.Cleanup(func() { DefaultMaxContentLength = oldMax })
+
+	return oldMax
+}

--- a/throughput_test.go
+++ b/throughput_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func BenchmarkAsyncThroughputLarge(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
@@ -39,6 +41,8 @@ func BenchmarkAsyncThroughputLarge(b *testing.B) {
 }
 
 func BenchmarkSyncThroughputLarge(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	emptyLogger := logging.Test(b, logging.Noop, b.Name())
@@ -62,6 +66,8 @@ func BenchmarkSyncThroughputLarge(b *testing.B) {
 }
 
 func BenchmarkTCPThroughput(b *testing.B) {
+	DisableMaxContentLength(b)
+
 	const testSize = 100
 
 	reader, writer, err := pair.New()


### PR DESCRIPTION
Add magic header bytes and a maximum content length to improve how we handle unexpected packets. Connections that violate these requirements are closed immediately before their contents are processed.